### PR TITLE
Update Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian
+FROM balenalib/rpi-raspbian:stretch
 
 MAINTAINER Evan Salter <evanearlsalter@gmail.com>
 


### PR DESCRIPTION
Since the resin docker hub is not maintained anymore it would be nice to switch to a maintained version, now from balenalib.